### PR TITLE
abstract out the context cancel logic for reuse

### DIFF
--- a/interrupt.go
+++ b/interrupt.go
@@ -1,0 +1,26 @@
+package typescript
+
+import (
+	"context"
+
+	"github.com/dop251/goja"
+)
+
+func startInterruptable(ctx context.Context, vm *goja.Runtime) chan struct{} {
+	done := make(chan struct{})
+	started := make(chan struct{})
+	go func() {
+		// Inform the parent go-routine that we've started, this prevents a race condition where the
+		// runtime would beat the context cancellation in unit tests even though the context started
+		// out in a 'cancelled' state.
+		close(started)
+		select {
+		case <-ctx.Done():
+			vm.Interrupt("context halt")
+		case <-done:
+			return
+		}
+	}()
+	<-started
+	return done
+}


### PR DESCRIPTION
First off: LOVE this project!

This change is minor, but I wanted to submit it separate from the adds I'm about to make to keep those merges smaller. Essentially I'm adding the ability to use goja.RunProgram similar to Evaluate.

NOTE: some of these changes were autogenerated by gofmt. I can remove them if you want.